### PR TITLE
fix: reduce S3 poll frequency to 5 min and extend default timeout

### DIFF
--- a/.github/scripts/poll-validation.sh
+++ b/.github/scripts/poll-validation.sh
@@ -23,7 +23,7 @@ ARN_X86_SLIM=""
 ARN_ARM64_SLIM=""
 OS_TIER=""
 RUN_ID=""
-TIMEOUT=${VALIDATION_TIMEOUT_S:-600}
+TIMEOUT=${VALIDATION_TIMEOUT_S:-1800}
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -114,7 +114,7 @@ PYEOF
 
   remaining=$((end - SECONDS))
   echo "  Waiting... (${remaining}s remaining)"
-  sleep 15
+  sleep 300
 done
 
 echo "ERROR: Timeout after ${TIMEOUT}s — no result at s3://${RESULTS_BUCKET}/${KEY}"

--- a/.github/workflows/validate-layer.yml
+++ b/.github/workflows/validate-layer.yml
@@ -46,6 +46,7 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION


Polling every 15s was noisy and unnecessary — validation takes several minutes on the orchestrator side. Switch to 300s sleep so the job only checks when results are realistically ready.

Default VALIDATION_TIMEOUT_S raised from 600s to 1800s so at least 5–6 polls occur before giving up. Added timeout-minutes: 35 on the validate job to match.