### PR TITLE
feat: decouple ECR from layer publish, show per-version regions in Slack

### DIFF
--- a/.github/workflows/publish-dotnet.yml
+++ b/.github/workflows/publish-dotnet.yml
@@ -79,6 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       failure_summary: ${{ steps.publish.outputs.failure_summary }}
+      ecr_failure_summary: ${{ steps.publish.outputs.ecr_failure_summary }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
@@ -101,6 +102,7 @@ jobs:
           PUBLISH_REGIONS: ${{ steps.region-retry-load.outputs.publish_regions || inputs.regions }}
           LAYER_REGIONS: ${{ vars.LAYER_REGIONS }}
           S3_BUCKET_PREFIX: ${{ vars.S3_BUCKET_PREFIX }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: |
           cd dotnet
           ./publish-layers.sh
@@ -125,6 +127,7 @@ jobs:
         with:
           language_name: Dotnet
           versions_json: '[{"key":"dotnet10","label":"Dotnet 10","job":"publish-dotnet","fallback":"${{ needs.publish-dotnet.result }}","failure_key":"dotnet"}]'
+          failure_summaries: ${{ needs.publish-dotnet.outputs.ecr_failure_summary }}
           slack_webhook: ${{ secrets.SLACK_VALIDATION_WEBHOOK }}
           gh_token: ${{ github.token }}
           repo: ${{ github.repository }}

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -97,6 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       failure_summary: ${{ steps.publish.outputs.failure_summary }}
+      ecr_failure_summary: ${{ steps.publish.outputs.ecr_failure_summary }}
     steps:
       - uses: actions/checkout@v4
       - name: Install publish dependencies
@@ -121,6 +122,7 @@ jobs:
           PUBLISH_REGIONS: ${{ steps.region-retry-load.outputs.publish_regions || inputs.regions }}
           LAYER_REGIONS: ${{ vars.LAYER_REGIONS }}
           S3_BUCKET_PREFIX: ${{ vars.S3_BUCKET_PREFIX }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: |
           cd extension
           ./publish-layer.sh
@@ -145,6 +147,7 @@ jobs:
         with:
           language_name: Extension (Go/AL2+AL2023)
           versions_json: '[{"key":"extension","label":"Extension (go/al2+al2023)","job":"publish-extension","fallback":"${{ needs.publish-extension.result }}","failure_key":"extension"}]'
+          failure_summaries: ${{ needs.publish-extension.outputs.ecr_failure_summary }}
           slack_webhook: ${{ secrets.SLACK_VALIDATION_WEBHOOK }}
           gh_token: ${{ github.token }}
           repo: ${{ github.repository }}

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -158,10 +158,12 @@ jobs:
           run_id: ${{ github.run_id }}
           run_attempt: ${{ github.run_attempt }}
       - name: Set up QEMU
+        if: always()
         uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64, amd64
       - name: Publish ECR image for ${{ matrix.java-version }}
+        if: always()
         id: publish-ecr
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -141,6 +141,7 @@ jobs:
           run_id: ${{ github.run_id }}
           run_attempt: ${{ github.run_attempt }}
       - name: Publish ECR image for nodejs${{ matrix.node-version }}
+        if: always()
         id: publish-ecr
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -198,6 +199,7 @@ jobs:
           run_id: ${{ github.run_id }}
           run_attempt: ${{ github.run_attempt }}
       - name: Publish universal ECR image
+        if: always()
         id: publish-ecr-universal
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -75,6 +75,7 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     outputs:
       failure_summary: ${{ steps.publish.outputs.failure_summary }}
+      ecr_failure_summary: ${{ steps.publish.outputs.ecr_failure_summary }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -95,6 +96,7 @@ jobs:
           PUBLISH_REGIONS: ${{ steps.region-retry-load.outputs.publish_regions || inputs.regions }}
           LAYER_REGIONS: ${{ vars.LAYER_REGIONS }}
           S3_BUCKET_PREFIX: ${{ vars.S3_BUCKET_PREFIX }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: |
           cd python
           ./publish-layers.sh python${{ matrix.python-version }}
@@ -115,6 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       failure_summary: ${{ steps.publish-universal.outputs.failure_summary }}
+      ecr_failure_summary: ${{ steps.publish-universal.outputs.ecr_failure_summary }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup
@@ -135,6 +138,7 @@ jobs:
           PUBLISH_REGIONS: ${{ steps.region-retry-load.outputs.publish_regions || inputs.regions }}
           LAYER_REGIONS: ${{ vars.LAYER_REGIONS }}
           S3_BUCKET_PREFIX: ${{ vars.S3_BUCKET_PREFIX }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: |
           cd python
           ./publish-layers.sh python
@@ -168,6 +172,9 @@ jobs:
               {"key":"3.14","label":"Python 3.14","job":"publish-python (3.14)","fallback":"${{ needs.publish-python.result }}","failure_key":"python-3.14"},
               {"key":"universal","label":"Python Universal","job":"publish-python-universal","fallback":"${{ needs.publish-python-universal.result }}","failure_key":"python-universal"}
             ]
+          failure_summaries: |
+            ${{ needs.publish-python.outputs.ecr_failure_summary }}
+            ${{ needs.publish-python-universal.outputs.ecr_failure_summary }}
           slack_webhook: ${{ secrets.SLACK_VALIDATION_WEBHOOK }}
           gh_token: ${{ github.token }}
           repo: ${{ github.repository }}

--- a/.github/workflows/publish-ruby.yml
+++ b/.github/workflows/publish-ruby.yml
@@ -93,6 +93,7 @@ jobs:
         ruby-version: [3.2, 3.3, 3.4]
     outputs:
       failure_summary: ${{ steps.publish.outputs.failure_summary }}
+      ecr_failure_summary: ${{ steps.publish.outputs.ecr_failure_summary }}
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Use Ruby ${{ matrix.ruby-version }}
@@ -125,6 +126,7 @@ jobs:
           PUBLISH_REGIONS: ${{ steps.region-retry-load.outputs.publish_regions || inputs.regions }}
           LAYER_REGIONS: ${{ vars.LAYER_REGIONS }}
           S3_BUCKET_PREFIX: ${{ vars.S3_BUCKET_PREFIX }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
         run: ./publish-layers.sh ruby${{ matrix.ruby-version }}
         working-directory: ruby
       - name: Save failed regions for re-run
@@ -153,6 +155,7 @@ jobs:
               {"key":"3.3","label":"Ruby 3.3","job":"publish-ruby (3.3)","fallback":"${{ needs.publish-ruby.result }}","failure_key":"ruby-3.3"},
               {"key":"3.4","label":"Ruby 3.4","job":"publish-ruby (3.4)","fallback":"${{ needs.publish-ruby.result }}","failure_key":"ruby-3.4"}
             ]
+          failure_summaries: ${{ needs.publish-ruby.outputs.ecr_failure_summary }}
           slack_webhook: ${{ secrets.SLACK_VALIDATION_WEBHOOK }}
           gh_token: ${{ github.token }}
           repo: ${{ github.repository }}

--- a/dotnet/publish-layers.sh
+++ b/dotnet/publish-layers.sh
@@ -37,8 +37,6 @@ function publish-dotnet-x86-64 {
     fi
 
     run_region_loop "$DOTNET_DIST_X86_64" dotnet x86_64 "$NEWRELIC_AGENT_VERSION"
-
-    publish_docker_ecr $DOTNET_DIST_X86_64 dotnet x86_64
 }
 
 function build-dotnet-arm64 {
@@ -60,8 +58,6 @@ function publish-dotnet-arm64 {
     fi
 
     run_region_loop "$DOTNET_DIST_ARM64" dotnet arm64 "$NEWRELIC_AGENT_VERSION"
-
-    publish_docker_ecr $DOTNET_DIST_ARM64 dotnet arm64
 }
 
 # exmaple https://download.newrelic.com/dot_net_agent/latest_release/newrelic-dotnet-agent_amd64.tar.gz
@@ -108,10 +104,15 @@ case "${1:-}" in
     done
     ;;
 *)
+    layer_rc=0
     build-dotnet-arm64
-    publish-dotnet-arm64
+    publish-dotnet-arm64 || layer_rc=$?
+    publish_ecr_safe $DOTNET_DIST_ARM64 dotnet arm64
     build-dotnet-x86-64
-    publish-dotnet-x86-64
+    publish-dotnet-x86-64 || layer_rc=$?
+    publish_ecr_safe $DOTNET_DIST_X86_64 dotnet x86_64
+    finalize_ecr_results "dotnet"
+    [[ $layer_rc -eq 0 ]] || exit $layer_rc
     ;;
 esac
 

--- a/extension/publish-layer.sh
+++ b/extension/publish-layer.sh
@@ -65,12 +65,16 @@ case "${1:-publish}" in
   "publish-staging")  publish-staging ;;
   "cleanup-staging")  cleanup-staging ;;
   *)
+    layer_rc=0
     build-layer-x86
-    publish-layer-x86
-    publish_docker_ecr $EXTENSION_DIST_ZIP_X86_64 extension x86_64
+    publish-layer-x86 || layer_rc=$?
+    publish_ecr_safe $EXTENSION_DIST_ZIP_X86_64 extension x86_64
 
     build-layer-arm64
-    publish-layer-arm64
-    publish_docker_ecr $EXTENSION_DIST_ZIP_ARM64 extension arm64
+    publish-layer-arm64 || layer_rc=$?
+    publish_ecr_safe $EXTENSION_DIST_ZIP_ARM64 extension arm64
+
+    finalize_ecr_results "extension"
+    [[ $layer_rc -eq 0 ]] || exit $layer_rc
     ;;
 esac

--- a/python/publish-layers.sh
+++ b/python/publish-layers.sh
@@ -144,60 +144,81 @@ case "$1" in
         publish_docker_ecr $PY_DIST_X86_64 python x86_64
         ;;
     "python")
+        layer_rc=0
         build_universal_python_layer arm64
-        publish_universal_python_layer arm64
-        publish_docker_ecr $PY_DIST_ARM64 python arm64
+        publish_universal_python_layer arm64 || layer_rc=$?
+        publish_ecr_safe $PY_DIST_ARM64 python arm64
         build_universal_python_layer x86_64
-        publish_universal_python_layer x86_64
-        publish_docker_ecr $PY_DIST_X86_64 python x86_64
+        publish_universal_python_layer x86_64 || layer_rc=$?
+        publish_ecr_safe $PY_DIST_X86_64 python x86_64
+        finalize_ecr_results "python-universal"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.9")
+        layer_rc=0
         build_python_layer 3.9 arm64
-        publish_python_layer 3.9 arm64
-        publish_docker_ecr $PY39_DIST_ARM64 python3.9 arm64
+        publish_python_layer 3.9 arm64 || layer_rc=$?
+        publish_ecr_safe $PY39_DIST_ARM64 python3.9 arm64
         build_python_layer 3.9 x86_64
-        publish_python_layer 3.9 x86_64
-        publish_docker_ecr $PY39_DIST_X86_64 python3.9 x86_64
+        publish_python_layer 3.9 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY39_DIST_X86_64 python3.9 x86_64
+        finalize_ecr_results "python3.9"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.10")
+        layer_rc=0
         build_python_layer 3.10 arm64
-        publish_python_layer 3.10 arm64
-        publish_docker_ecr $PY310_DIST_ARM64 python3.10 arm64
+        publish_python_layer 3.10 arm64 || layer_rc=$?
+        publish_ecr_safe $PY310_DIST_ARM64 python3.10 arm64
         build_python_layer 3.10 x86_64
-        publish_python_layer 3.10 x86_64
-        publish_docker_ecr $PY310_DIST_X86_64 python3.10 x86_64
+        publish_python_layer 3.10 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY310_DIST_X86_64 python3.10 x86_64
+        finalize_ecr_results "python3.10"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.11")
+        layer_rc=0
         build_python_layer 3.11 arm64
-        publish_python_layer 3.11 arm64
-        publish_docker_ecr $PY311_DIST_ARM64 python3.11 arm64
+        publish_python_layer 3.11 arm64 || layer_rc=$?
+        publish_ecr_safe $PY311_DIST_ARM64 python3.11 arm64
         build_python_layer 3.11 x86_64
-        publish_python_layer 3.11 x86_64
-        publish_docker_ecr $PY311_DIST_X86_64 python3.11 x86_64
+        publish_python_layer 3.11 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY311_DIST_X86_64 python3.11 x86_64
+        finalize_ecr_results "python3.11"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.12")
+        layer_rc=0
         build_python_layer 3.12 arm64
-        publish_python_layer 3.12 arm64
-        publish_docker_ecr $PY312_DIST_ARM64 python3.12 arm64
+        publish_python_layer 3.12 arm64 || layer_rc=$?
+        publish_ecr_safe $PY312_DIST_ARM64 python3.12 arm64
         build_python_layer 3.12 x86_64
-        publish_python_layer 3.12 x86_64
-        publish_docker_ecr $PY312_DIST_X86_64 python3.12 x86_64
+        publish_python_layer 3.12 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY312_DIST_X86_64 python3.12 x86_64
+        finalize_ecr_results "python3.12"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.13")
+        layer_rc=0
         build_python_layer 3.13 arm64
-        publish_python_layer 3.13 arm64
-        publish_docker_ecr $PY313_DIST_ARM64 python3.13 arm64
+        publish_python_layer 3.13 arm64 || layer_rc=$?
+        publish_ecr_safe $PY313_DIST_ARM64 python3.13 arm64
         build_python_layer 3.13 x86_64
-        publish_python_layer 3.13 x86_64
-        publish_docker_ecr $PY313_DIST_X86_64 python3.13 x86_64
+        publish_python_layer 3.13 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY313_DIST_X86_64 python3.13 x86_64
+        finalize_ecr_results "python3.13"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "python3.14")
+        layer_rc=0
         build_python_layer 3.14 arm64
-        publish_python_layer 3.14 arm64
-        publish_docker_ecr $PY314_DIST_ARM64 python3.14 arm64
+        publish_python_layer 3.14 arm64 || layer_rc=$?
+        publish_ecr_safe $PY314_DIST_ARM64 python3.14 arm64
         build_python_layer 3.14 x86_64
-        publish_python_layer 3.14 x86_64
-        publish_docker_ecr $PY314_DIST_X86_64 python3.14 x86_64
+        publish_python_layer 3.14 x86_64 || layer_rc=$?
+        publish_ecr_safe $PY314_DIST_X86_64 python3.14 x86_64
+        finalize_ecr_results "python3.14"
+        [[ $layer_rc -eq 0 ]] || exit $layer_rc
         ;;
     "publish-staging-python3.14")
         build_python_layer 3.14 arm64

--- a/ruby/publish-layers.sh
+++ b/ruby/publish-layers.sh
@@ -181,28 +181,37 @@ function publish_ruby_for_arch {
 set +u # permit $1 to be unbound so that '*' matches it when no args are present
 case "$1" in
   "ruby3.4")
+    layer_rc=0
     build-ruby34-arm64
-    publish-ruby34-arm64
-    publish_docker_ecr $RB34_DIST_ARM64 ruby3.4 arm64
+    publish-ruby34-arm64 || layer_rc=$?
+    publish_ecr_safe $RB34_DIST_ARM64 ruby3.4 arm64
     build-ruby34-x86
-    publish-ruby34-x86
-    publish_docker_ecr $RB34_DIST_X86_64 ruby3.4 x86_64
+    publish-ruby34-x86 || layer_rc=$?
+    publish_ecr_safe $RB34_DIST_X86_64 ruby3.4 x86_64
+    finalize_ecr_results "ruby3.4"
+    [[ $layer_rc -eq 0 ]] || exit $layer_rc
     ;;
   "ruby3.3")
+    layer_rc=0
     build-ruby33-arm64
-    publish-ruby33-arm64
-    publish_docker_ecr $RB33_DIST_ARM64 ruby3.3 arm64
+    publish-ruby33-arm64 || layer_rc=$?
+    publish_ecr_safe $RB33_DIST_ARM64 ruby3.3 arm64
     build-ruby33-x86
-    publish-ruby33-x86
-    publish_docker_ecr $RB33_DIST_X86_64 ruby3.3 x86_64
+    publish-ruby33-x86 || layer_rc=$?
+    publish_ecr_safe $RB33_DIST_X86_64 ruby3.3 x86_64
+    finalize_ecr_results "ruby3.3"
+    [[ $layer_rc -eq 0 ]] || exit $layer_rc
     ;;
   "ruby3.2")
+    layer_rc=0
     build-ruby32-arm64
-    publish-ruby32-arm64
-    publish_docker_ecr $RB32_DIST_ARM64 ruby3.2 arm64
+    publish-ruby32-arm64 || layer_rc=$?
+    publish_ecr_safe $RB32_DIST_ARM64 ruby3.2 arm64
     build-ruby32-x86
-    publish-ruby32-x86
-    publish_docker_ecr $RB32_DIST_X86_64 ruby3.2 x86_64
+    publish-ruby32-x86 || layer_rc=$?
+    publish_ecr_safe $RB32_DIST_X86_64 ruby3.2 x86_64
+    finalize_ecr_results "ruby3.2"
+    [[ $layer_rc -eq 0 ]] || exit $layer_rc
     ;;
   "publish-staging-ruby3.4")
     build-ruby34-arm64


### PR DESCRIPTION
ECR publish now runs independently (if: always()) so a region failure in layer publishing no longer prevents Docker images from being pushed.

Slack notification now downloads failed-regions-* artifacts and shows which specific regions failed per version instead of generic message. Added failure_key to all versions_json entries and run_attempt input to all 6 notify-slack jobs. ECR failures still surfaced separately.